### PR TITLE
Fix video cleanup on project switch

### DIFF
--- a/DPyL_video.py
+++ b/DPyL_video.py
@@ -536,15 +536,25 @@ class VideoItem(QGraphicsVideoItem):
         # 3. メディアソース解放
         self.player.setSource(QUrl())
 
-        # 4. プレイヤー/オーディオの破棄
+        # 4. 出力のデタッチ
+        #    VideoItem の削除中に QMediaPlayer がフレームを
+        #    送出しようとするとクラッシュすることがあるため、
+        #    明示的に出力を解除してから破棄する
+        self.player.setVideoOutput(None)
+        try:
+            self.player.setAudioOutput(None)
+        except Exception:
+            pass
+
+        # 5. プレイヤー/オーディオの破棄
         self.player.deleteLater()
         self.audio.deleteLater()
-
-        # 5. シーンから自身を削除
+        
+        # 6. シーンから自身を削除
         if self.scene():
             self.scene().removeItem(self)
 
-        # 6. 最後に自身もdeleteLaterで非同期削除
+        # 7. 最後に自身もdeleteLaterで非同期削除
         self.deleteLater()
         
     # --------------------------------------------------------------


### PR DESCRIPTION
## Summary
- detach QMediaPlayer outputs before deleting VideoItem

## Testing
- `python -m py_compile DPyL_video.py`

------
https://chatgpt.com/codex/tasks/task_e_683f497f03a48330a5003fe38bfedf56