### PR TITLE
Add warp effect when loading JSON project

### DIFF
--- a/DPyL_classes.py
+++ b/DPyL_classes.py
@@ -1645,7 +1645,7 @@ class JSONItem(LauncherItem):
 
         # プロジェクトファイルなら内部ロード
         if self._is_launcher_project():
-            win._load_json(p)
+            win.play_warp_and_load_json(p)
             return
 
         # フォールバック：通常オープン


### PR DESCRIPTION
## Summary
- show warp-style transition when opening JSON project files
- load project after warp effect completes

## Testing
- `python -m py_compile desktopPyLauncher.py DPyL_classes.py`

------
https://chatgpt.com/codex/tasks/task_e_6854323fa4ec83308c6c0468437c250c