### PR TITLE
Fix warp effect visibility

### DIFF
--- a/desktopPyLauncher.py
+++ b/desktopPyLauncher.py
@@ -459,9 +459,9 @@ class SparkEffectItem(QGraphicsItem):
 class WarpStarEffectItem(QGraphicsItem):
     """シンプルなワープスターエフェクト"""
 
-    def __init__(self, scene_rect, duration=800, on_finished=None):
+    def __init__(self, effect_rect, duration=800, on_finished=None):
         super().__init__()
-        self.scene_rect = scene_rect
+        self.effect_rect = effect_rect
         self.duration = duration / 1000.0
         self.on_finished = on_finished
         self.start_time = time.time()
@@ -470,15 +470,15 @@ class WarpStarEffectItem(QGraphicsItem):
         self.setZValue(10000)
 
         import random
-        cx = self.scene_rect.center().x()
-        cy = self.scene_rect.center().y()
+        cx = self.effect_rect.center().x()
+        cy = self.effect_rect.center().y()
 
         # Create approximately 100 stars randomly placed on the screen. Each star
         # stores its flight angle, initial distance from the centre, current
         # distance and speed.
         for _ in range(100):
-            x = random.uniform(self.scene_rect.left(), self.scene_rect.right())
-            y = random.uniform(self.scene_rect.top(), self.scene_rect.bottom())
+            x = random.uniform(self.effect_rect.left(), self.effect_rect.right())
+            y = random.uniform(self.effect_rect.top(), self.effect_rect.bottom())
             angle = math.atan2(y - cy, x - cx)
             start_dist = math.hypot(x - cx, y - cy)
             speed = random.uniform(600, 1200)
@@ -490,7 +490,7 @@ class WarpStarEffectItem(QGraphicsItem):
         self.timer.start(16)
 
     def boundingRect(self):
-        return self.scene_rect
+        return self.effect_rect
 
     def update_animation(self):
         current = time.time()
@@ -513,8 +513,8 @@ class WarpStarEffectItem(QGraphicsItem):
 
     def paint(self, painter, option, widget=None):
         painter.setPen(QPen(QColor("white"), 2))
-        cx = self.scene_rect.center().x()
-        cy = self.scene_rect.center().y()
+        cx = self.effect_rect.center().x()
+        cy = self.effect_rect.center().y()
         for angle, start, current, _ in self.stars:
             x1 = cx + math.cos(angle) * start
             y1 = cy + math.sin(angle) * start
@@ -804,7 +804,9 @@ class CanvasView(QGraphicsView):
             self.warp_effect = None
 
         scene_rect = self.scene().sceneRect()
-        self.warp_effect = WarpStarEffectItem(scene_rect, on_finished=on_finished)
+        view_rect = self.mapToScene(self.viewport().rect()).boundingRect()
+        effect_rect = scene_rect.united(view_rect)
+        self.warp_effect = WarpStarEffectItem(effect_rect, on_finished=on_finished)
         self.scene().addItem(self.warp_effect)
     def dragEnterEvent(self, e): 
         # ファイルやURLドロップの受付


### PR DESCRIPTION
## Summary
- ensure warp effect covers viewport if the scene is small
- refactor WarpStarEffectItem to use effect_rect

## Testing
- `python -m py_compile desktopPyLauncher.py DPyL_classes.py DPyL_note.py DPyL_debug.py DPyL_shapes.py DPyL_effects.py DPyL_ticker.py DPyL_group.py DPyL_utils.py DPyL_marker.py DPyL_video.py`

------
https://chatgpt.com/codex/tasks/task_e_685438c398d48330bed2c82c21054cdf