### PR TITLE
Enable middle-click mode toggle on items

### DIFF
--- a/desktopPyLauncher.py
+++ b/desktopPyLauncher.py
@@ -872,6 +872,14 @@ class CanvasView(QGraphicsView):
                 ev.accept()
                 return
         super().mousePressEvent(ev)
+
+    def mouseReleaseEvent(self, ev):
+        """Middle button toggle for edit/run mode"""
+        if ev.button() == Qt.MouseButton.MiddleButton:
+            self.win.a_run.trigger()
+            ev.accept()
+            return
+        super().mouseReleaseEvent(ev)
         
     def _on_vscroll(self, value: int):
         vbar = self.verticalScrollBar()


### PR DESCRIPTION
## Summary
- handle middle mouse button release in `CanvasView`
- trigger edit/run mode toggle even when clicked on an item

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685e9a793c70833082566bfc0f90b34b